### PR TITLE
fix package resolve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 before_script:
   - docker build -t ${KBC_APP_REPOSITORY} .
 script: 
-  - docker run ${KBC_APP_REPOSITORY} julia -e "using Pkg; Pkg.activate(\"/code\"); Pkg.update(); Pkg.build(); Pkg.test()"
+  - docker run ${KBC_APP_REPOSITORY} julia -e "using Pkg; Pkg.activate(\"/code\"); Pkg.build(); Pkg.test()"
 after_success:
   - docker images
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keboola/docker-custom-julia:0.1.0
+FROM quay.io/keboola/docker-custom-julia:0.2.0
 
 WORKDIR /code
 

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -3,31 +3,23 @@
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[BinaryProvider]]
-deps = ["Compat", "CredentialsHandler", "Libdl", "Pkg", "SHA", "TOML", "Test"]
-uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-
 [[CSV]]
 deps = ["CategoricalArrays", "DataFrames", "Dates", "Mmap", "Parsers", "PooledArrays", "Profile", "Tables", "Unicode", "WeakRefStrings"]
-git-tree-sha1 = "35205137ee2f5a9c1f358407e9ed0f1a17878919"
+git-tree-sha1 = "de1b0b47e8860ebda59594fa424709ed3e40fcd3"
 uuid = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
-version = "0.5.11"
+version = "0.5.12"
 
 [[CategoricalArrays]]
-deps = ["Compat", "DataAPI", "Future", "JSON", "Missings", "Printf", "Reexport"]
-git-tree-sha1 = "13240cfcc884837fc1aa89b60d500a652bcc3f10"
+deps = ["Compat", "DataAPI", "Future", "JSON", "Missings", "Printf", "Reexport", "Unicode"]
+git-tree-sha1 = "5f4400b24adb1fbed17a9dcc1e8ab8aaf5b03d1f"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.5.5"
+version = "0.6.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
 git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "2.1.0"
-
-[[CredentialsHandler]]
-deps = ["Base64", "HTTP", "TOML"]
-uuid = "864e158e-919d-11e8-198e-cfe890ec4681"
 
 [[DataAPI]]
 git-tree-sha1 = "8903f0219d3472543fc4b2f5ebaf675a07f817c0"
@@ -36,9 +28,9 @@ version = "1.0.1"
 
 [[DataFrames]]
 deps = ["CategoricalArrays", "Compat", "DataAPI", "InvertedIndices", "IteratorInterfaceExtensions", "Missings", "PooledArrays", "Printf", "REPL", "Reexport", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
-git-tree-sha1 = "934b75a90b6cb315f9ea0df961768a02c1da1612"
+git-tree-sha1 = "271528230c65a4517522e2968c3deed76b92b998"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.19.3"
+version = "0.19.4"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
@@ -66,13 +58,6 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 [[Future]]
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
-
-[[HTTP]]
-deps = ["Base64", "Dates", "Distributed", "IniFile", "JSON", "MbedTLS", "Sockets", "Test"]
-uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-
-[[IniFile]]
-uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -120,15 +105,10 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
-[[MbedTLS]]
-deps = ["BinaryProvider", "Dates", "Libdl", "Pkg", "Random", "Sockets"]
-uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-
 [[Missings]]
-deps = ["SparseArrays", "Test"]
-git-tree-sha1 = "f0719736664b4358aa9ec173077d4285775f8007"
+git-tree-sha1 = "29858ce6c8ae629cf2d733bffa329619a1c843d0"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "0.4.1"
+version = "0.4.2"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -141,12 +121,12 @@ version = "1.1.0"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "db2b35dedab3c0e46dc15996d170af07a5ab91c9"
+git-tree-sha1 = "ef0af6c8601db18c282d092ccbd2f01f3f0cd70b"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.3.6"
+version = "0.3.7"
 
 [[Pkg]]
-deps = ["BinaryProvider", "CredentialsHandler", "Dates", "HTTP", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "TOML", "UUIDs"]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[PooledArrays]]
@@ -202,10 +182,6 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-
-[[TOML]]
-deps = ["Dates"]
-uuid = "9d418dce-91a8-11e8-0173-7b01a971d501"
 
 [[TableTraits]]
 deps = ["IteratorInterfaceExtensions"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -22,4 +22,4 @@ docker push ${REPOSITORY}:latest
 
 # Deploy to KBC -> update the tag in Keboola Developer Portal (needs $KBC_DEVELOPERPORTAL_VENDOR & $KBC_DEVELOPERPORTAL_APP)
 docker run --rm -e KBC_DEVELOPERPORTAL_USERNAME -e KBC_DEVELOPERPORTAL_PASSWORD -e KBC_DEVELOPERPORTAL_URL \
-    quay.io/keboola/developer-portal-cli-v2:latest update-app-repository ${KBC_DEVELOPERPORTAL_VENDOR} ${KBC_DEVELOPERPORTAL_APP} ${TRAVIS_TAG}
+    quay.io/keboola/developer-portal-cli-v2:latest update-app-repository ${KBC_DEVELOPERPORTAL_VENDOR} ${KBC_DEVELOPERPORTAL_APP} ${TRAVIS_TAG} ecr ${REPOSITORY}

--- a/src/KeboolaConnectionTransformation.jl
+++ b/src/KeboolaConnectionTransformation.jl
@@ -24,7 +24,9 @@ function run()::Integer
             throw(ArgumentError("Failed to install package '" * package * "' error: " * e.msg))
         end
     end
-    Pkg.resolve()
+    if length(packages) > 0
+        Pkg.resolve()
+    end
 
     # Change current working directory so that relative paths work
     cd(datadir)

--- a/src/KeboolaConnectionTransformation.jl
+++ b/src/KeboolaConnectionTransformation.jl
@@ -17,14 +17,14 @@ function run()::Integer
 
     # install packages
     packages = get(parameters, "packages", [])
-    for package in Iterators.Stateful(packages)
-        try
-            Pkg.add(package)
-        catch e
-            throw(ArgumentError("Failed to install package '" * package * "' error: " * e.msg))
-        end
-    end
     if length(packages) > 0
+        for package in Iterators.Stateful(packages)
+            try
+                Pkg.add(package)
+            catch e
+                throw(ArgumentError("Failed to install package '" * package * "' error: " * e.msg))
+            end
+        end
         Pkg.resolve()
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,25 @@ end
     delete!(ENV, "KBC_DATADIR")
 end
 
+@testset "no packages" begin
+    data = getconfigdata()
+    data["parameters"] = Dict(
+        "packages" => [],
+        "script" => ["println(\"Hello\")\nprintln(\"World\")"]
+    )
+    path = createconfig(data)
+    ENV["KBC_DATADIR"] = path
+    @test KeboolaConnectionTransformation.run() == 0
+
+    open(joinpath(path, "script.jl"), "r") do file
+        script = read(file, String)
+        @test script == "println(\"Hello\")\nprintln(\"World\")"
+    end
+    @test pwd() == path
+
+    delete!(ENV, "KBC_DATADIR")
+end
+
 @testset "invalid package" begin
     data = getconfigdata()
     data["parameters"] = Dict(


### PR DESCRIPTION
this looks ugly: 
call package resolve only when there are some packages, otherwise it fails with error
`ERROR: LoadError: Package CredentialsHandler [864e158e-919d-11e8-198e-cfe890ec4681] not found in a registry.`
https://connection.keboola.com/admin/projects/6716/jobs/536478492?q=
which i don't really understand, but i does that :/

the test is not truly testing this, because it fails only when the transformation is run, not during tests :/

also fixes deploy script to always set the ECR repository (was using old deploy.sh which didn't do that)

--- edit

so what i probably did is a composer.lock-like mistake that i called pkg update on my local installation and not inside the docker image which lead to a different package set in the manifest.toml.  So now i updated the manifest from within the docker image, which removes the necessity to call pkg.update before tests (which was weird from the beginning)
